### PR TITLE
Refactor Shiftit to be an opt-in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ To see a list of available options run:
 printf "%s " `ls scripts/opt-in | sed 's/\..*//'`; echo
 ```
 
+### Shiftit
+
+Shiftit is no longer under active development, if you want to install that, run `./setup.sh shiftit`
+
 ## Having problems?
 
 If you see errors from `brew`, try running `brew doctor` and include the diagnostic output in your issue submission.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ printf "%s " `ls scripts/opt-in | sed 's/\..*//'`; echo
 
 ### Shiftit
 
-Shiftit is no longer under active development, if you want to install that, run `./setup.sh shiftit`
+Shiftit is no longer under active development, if you want to install it you can add `shiftit` to either your `./setup.sh` or `./add_setup.sh` command line.
 
 ## Having problems?
 

--- a/scripts/common/applications-common.sh
+++ b/scripts/common/applications-common.sh
@@ -8,13 +8,6 @@ echo "Installing applications"
 # Utilities
 
 brew install --cask alfred
-# shiftit is not currently under active development
-# consider replacing with https://github.com/peterklijn/hammerspoon-shiftit
-#brew install --cask shiftit
-#echo
-#echo "configure shiftit to select 1/3 screen width, 1/2 screen width and 2/3 screen width:"
-#echo "`defaults write org.shiftitapp.ShiftIt multipleActionsCycleWindowSizes YES`"
-#echo
 brew install --cask dash
 brew install --cask postman
 brew install --cask quicklook-json

--- a/scripts/common/configurations.sh
+++ b/scripts/common/configurations.sh
@@ -2,6 +2,4 @@ echo
 echo "Configuring iTerm"
 cp files/com.googlecode.iterm2.plist ~/Library/Preferences
 
-echo "Configuring ShiftIt"
-open /Applications/ShiftIt.app
 

--- a/scripts/opt-in/shiftit.sh
+++ b/scripts/opt-in/shiftit.sh
@@ -1,0 +1,13 @@
+echo
+
+echo "shiftit is not currently under active development"
+echo "consider replacing with https://github.com/peterklijn/hammerspoon-shiftit"
+
+brew install --cask shiftit
+echo
+echo "configure shiftit to select 1/3 screen width, 1/2 screen width and 2/3 screen width:"
+echo "`defaults write org.shiftitapp.ShiftIt multipleActionsCycleWindowSizes YES`"
+echo
+
+echo "Configuring ShiftIt"
+open /Applications/ShiftIt.app


### PR DESCRIPTION
Since Shiftit is no longer officially supported, and we have commented out the installation process for it, we migrated it to be optional in the opt-in section.