### PR TITLE
Remove some programs that are installed by corporate policies

### DIFF
--- a/base_setup.sh
+++ b/base_setup.sh
@@ -18,7 +18,6 @@ clear
 
 # Place any applications that require the user to type in their password here
 brew install --cask github
-brew install --cask zoom
 
 . ${WORKSTATION_SETUP_HOME}/scripts/common/zsh-setup.sh
 . ${WORKSTATION_SETUP_HOME}/scripts/common/oh-my-zsh.sh

--- a/scripts/common/applications-common.sh
+++ b/scripts/common/applications-common.sh
@@ -21,12 +21,7 @@ brew install --cask iterm2
 
 # Browsers
 
-brew install --cask google-chrome
 brew install --cask firefox
-
-# Communication
-
-brew install --cask slack
 
 # Text Editors
 


### PR DESCRIPTION
On first boot, our laptops now install several programs, including Zoom, Chrome, and Slack, making the lines removed here redundant.