### PR TITLE
Add some lines to make the overall execution less likely to fail

### DIFF
--- a/scripts/common/git.sh
+++ b/scripts/common/git.sh
@@ -11,9 +11,15 @@ brew install vim
 echo "GitHub CLI -- gh"
 brew install gh
 
+# All these applications are independent, so if one
+# fails to install, don't stop.
+set +e
+
 brew install --cask rowanj-gitx
 brew install --cask sourcetree
 brew install --cask gitup
+
+set -e
 
 echo
 echo "Putting a sample git-pair file in ~/.pairs"

--- a/scripts/opt-in/ruby.sh
+++ b/scripts/opt-in/ruby.sh
@@ -14,6 +14,8 @@ if ! command -v rvm > /dev/null; then
   curl -sSL https://rvm.io/mpapis.asc | gpg --import -
   curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
   curl -sSL https://get.rvm.io | bash -s stable
+
+  source ~/.rvm/scripts/rvm
 else
   echo 'RVM Installed'
 fi

--- a/scripts/opt-in/ruby.sh
+++ b/scripts/opt-in/ruby.sh
@@ -15,21 +15,20 @@ if ! command -v rvm > /dev/null; then
   curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
   curl -sSL https://get.rvm.io | bash -s stable
 
-  source ~/.rvm/scripts/rvm
+  # Load RVM into a shell session *as a function*
+  if [[ -s "$HOME/.rvm/scripts/rvm" ]] ; then
+    # First try to load from a user install
+    source "$HOME/.rvm/scripts/rvm"
+  elif [[ -s '/usr/local/rvm/scripts/rvm' ]] ; then
+    # Then try to load from a root install
+    source '/usr/local/rvm/scripts/rvm'
+  else
+    printf "ERROR: An RVM installation was not found.\n"
+  fi
 else
   echo 'RVM Installed'
 fi
 
-# Load RVM into a shell session *as a function*
-if [[ -s "$HOME/.rvm/scripts/rvm" ]] ; then
-  # First try to load from a user install
-  source "$HOME/.rvm/scripts/rvm"
-elif [[ -s '/usr/local/rvm/scripts/rvm' ]] ; then
-  # Then try to load from a root install
-  source '/usr/local/rvm/scripts/rvm'
-else
-  printf "ERROR: An RVM installation was not found.\n"
-fi
 
 if ! [[ $(rvm ls) == *"${ruby_version}"* ]]; then
   echo "Installing Ruby ${ruby_version}"


### PR DESCRIPTION
The three cask installs are not idempotent, so unsetting `e` around them allows the script to run a second time without failing.

When ruby was installed on my machine, `rvm` was not available as a command, and the script broke a few lines down.  I'm not sure if this is the right fix, because there's several lines of code after this that try to do the same thing.  This might need more investigation.