### PR TITLE
Remove yes from homebrew execution

### DIFF
--- a/base_setup.sh
+++ b/base_setup.sh
@@ -8,11 +8,6 @@ set -e
 
 . _init.sh
 
-echo "Caching sudo password..."
-sudo -K
-sudo true;
-clear
-
 # Note: Start by ensuring that homebrew is installed
 . ${WORKSTATION_SETUP_HOME}/scripts/common/homebrew.sh
 

--- a/scripts/common/homebrew.sh
+++ b/scripts/common/homebrew.sh
@@ -4,7 +4,7 @@ if hash brew 2>/dev/null; then
   echo "Homebrew is already installed!"
 else
   echo "Installing Homebrew..."
-  yes '' | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
 echo


### PR DESCRIPTION
In my machine's `/etc/sudoers` file, there is the line:
`Defaults timestamp_timeout=0`

I'm not clear where this line comes from, Shane doesn't think we have a corporate policy that enforces it, but the effect of that line is that `sudo` prompts for my password every time, without a grace period.

What this means for this script is that when homebrew's installation is run, it will prompt for my password, despite the "password caching" lines (that are removed in this PR), and `yes` will spam newlines until three password failures, and homebrew will error out because it doesn't think you have admin access, because you failed to enter your password.

Overall, this will make homebrew more annoying to install, as you will need to enter your password 6 or 7 times, but I thought it would be an easier fix than telling people to edit their `/etc/sudoers` file in the README before running the script.